### PR TITLE
Adds Download Attribute

### DIFF
--- a/Resources/views/admin/logviewers/index.blade.php
+++ b/Resources/views/admin/logviewers/index.blade.php
@@ -108,7 +108,7 @@
                         <div class="col-md-12">
                             <div class="p-3">
                                 @if($data_logs['current_file'])
-                                    <a href="?dl={{ \Illuminate\Support\Facades\Crypt::encrypt($data_logs['current_file']) }}{{ ($data_logs['current_folder']) ? '&f=' . \Illuminate\Support\Facades\Crypt::encrypt($data_logs['current_folder']) : '' }}">
+                                    <a download href="?dl={{ \Illuminate\Support\Facades\Crypt::encrypt($data_logs['current_file']) }}{{ ($data_logs['current_folder']) ? '&f=' . \Illuminate\Support\Facades\Crypt::encrypt($data_logs['current_folder']) : '' }}">
                                         <span class="fa fa-download"></span> Download file
                                     </a>
                                     |


### PR DESCRIPTION
This PR adds the `download` attribute to the log file download link.

See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download)