### PR TITLE
Corrects Table Footer Markup

### DIFF
--- a/Resources/views/admin/logviewers/index.blade.php
+++ b/Resources/views/admin/logviewers/index.blade.php
@@ -88,7 +88,7 @@
                                     <?php endforeach; ?>
                                     <?php endif; ?>
                                     </tbody>
-                                    <thead>
+                                    <tfoot>
                                     <tr>
                                         @if ($data_logs['standardFormat'])
                                             <th>Level</th>
@@ -99,7 +99,7 @@
                                         @endif
                                         <th>Content</th>
                                     </tr>
-                                    </thead>
+                                    </tfoot>
                                 </table>
                             </div>
                         </div>


### PR DESCRIPTION
This PR corrects the markup of the table footer from a `thead` to a `tfoot`